### PR TITLE
Import error and middleware fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ Angular expanding them.
    setting.
  - Set `settings.NG_CLOSING_TAG` and `settings.NG_OPENING_TAG` setting. This has no default as it's essential that it is
    set to match your `$interpolateProvider.startSymbol('[[').endSymbol(']]');` setting.
+ - Set `settings.NG_APP_MARKER` if you don't use `ng-app` to bootstrap your angular application (you use the programmatic bootstrap). The same string need to be added as an attribute to the body element.
 
 ## USE WITH CAUTION!
 

--- a/angular/middleware.py
+++ b/angular/middleware.py
@@ -4,7 +4,7 @@ from django.conf import settings
 from django.core.exceptions import SuspiciousOperation
 
 
-_NG_APP_MARKER = "ng-app"
+_NG_APP_MARKER = getattr(settings, "NG_APP_MARKER", "ng-app")
 _NG_SAFE_ATTRIBUTE = "_ng_safe"
 
 
@@ -20,7 +20,7 @@ class EnsureAngularProtectionMiddleware(object):
     """
 
     def process_response(self, request, response):
-        if not settings.DEBUG:
+        if not settings.DEBUG or 'text/html' not in response.get('Content-Type', ''):
             return response
 
         def check_content(content):
@@ -28,7 +28,8 @@ class EnsureAngularProtectionMiddleware(object):
             if _NG_APP_MARKER.encode() in content:
                 if not getattr(response, _NG_SAFE_ATTRIBUTE, False):
                     raise SuspiciousOperation(
-                        "Angular template not rendered with angular.shorcuts.render"
+                        ("Angular template not rendered with angular.shorcuts.render or "
+                         "attempt to access Django context in protected area.")
                     )
             return content
 

--- a/angular/templatetags/angular.py
+++ b/angular/templatetags/angular.py
@@ -4,7 +4,7 @@ from django.conf import settings
 from django import template
 from django.core.exceptions import ImproperlyConfigured
 
-from angular.shortcuts import _local, _is_safe_type
+from ..shortcuts import _local, _is_safe_type
 
 register = template.Library()
 

--- a/angular/templatetags/angular.py
+++ b/angular/templatetags/angular.py
@@ -1,10 +1,11 @@
-import six
+from __future__ import absolute_import
 
+import six
 from django.conf import settings
 from django import template
 from django.core.exceptions import ImproperlyConfigured
 
-from ..shortcuts import _local, _is_safe_type
+from angular.shortcuts import _local, _is_safe_type
 
 register = template.Library()
 


### PR DESCRIPTION
Fixes:
- Middleware runs only on html responses
- Solve error importing shortcuts module in angular

Improvements:
- make NG_APP_MARKER configurable